### PR TITLE
Changing JS loading order

### DIFF
--- a/app/layouts/main.static.hbs
+++ b/app/layouts/main.static.hbs
@@ -43,8 +43,8 @@ _options:
       {{content}}
     </main>
     {{> footer class_name=footer_class_name}}
-    <script type="text/javascript" src="{{url_base}}DIGEST(/app.js)"></script>
     <script type="text/javascript" src="{{url_base}}DIGEST(/vendor.js)"></script>
+    <script type="text/javascript" src="{{url_base}}DIGEST(/app.js)"></script>
     <script>require('initialize');</script>
   </body>
 </html>


### PR DESCRIPTION
- It was loading `app.js` before `vendor.js`. All the dependencies were loaded after the app has already run. It should fix the `Cannot find module 'process' from '/'` error