### PR TITLE
Landing page ignored in robots.txt [#133592495]

### DIFF
--- a/app/assets/robots.txt
+++ b/app/assets/robots.txt
@@ -1,0 +1,4 @@
+# Ignore Landing Pages
+User-agent: *
+Disallow: /lp/
+


### PR DESCRIPTION
### Testing:
- Go to a robots.txt tester (e.g: https://technicalseo.com/seo-tools/robots-txt/)
- Check if everything in `/lp/` is blocked

### Tickets
- [x] https://www.pivotaltracker.com/story/show/133592495