### PR TITLE
feat: add `date_year` to hbs context

### DIFF
--- a/app/partials/footer.static.hbs
+++ b/app/partials/footer.static.hbs
@@ -23,7 +23,7 @@
           </a>
         </div>
         <span class="c-footer__company-name">
-          &copy; 2016 Honeypot GmbH
+          &copy; {{date_year}} Honeypot GmbH
         </span>
       </div>
     </div>

--- a/brunch-config.coffee
+++ b/brunch-config.coffee
@@ -45,6 +45,7 @@ module.exports =
             gtm_id: process.env.GTM_ID
             optimizely_id: process.env.OPTIMIZELY_ID
             rollbar_token: process.env.ROLLBAR_TOKEN
+            date_year: new Date().getFullYear()
           handlebars:
             enableProcessor:
               fileMatch: /\.static\.(hbs|handlebars)$/


### PR DESCRIPTION
Use hbs context to get the current year for copyright.

#712