### PR TITLE
Slider fix on New employer landing page for Firefox [#928]

### DIFF
--- a/app/styles/components/_landing-testimonial.scss
+++ b/app/styles/components/_landing-testimonial.scss
@@ -63,6 +63,7 @@
 
   &__img {
     height: 100%;
+    max-height: 120px;
   }
 
   &__text {


### PR DESCRIPTION
- Go to the new employers page https://staging.honeypot.co/pr-112/pages/for_employers_new
- Make sure the slider image isn't broken/displayed properly

Issue:
- [x] https://github.com/honeypotio/honeypot/issues/928