### PR TITLE
chore: configurable dev server port

### DIFF
--- a/brunch-config.coffee
+++ b/brunch-config.coffee
@@ -55,3 +55,4 @@ module.exports =
       ]
   server:
     path: 'app.js'
+    port: 4000

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": ""
   },
   "scripts": {
-    "start": "brunch watch --server --port 4000",
+    "start": "brunch watch --server",
     "test": "mocha 'tests/**/*.spec.js' --compilers js:babel-core/register",
     "test server": "mocha 'tests/**/*.spec.js' --compilers js:babel-core/register --watch",
     "build": "brunch build --production && ./scripts/create_links",


### PR DESCRIPTION
The default port is now `4000`. If we want to start the dev server with a different port we can just
pass the port arg to npm scripts e.g. `npm start -- --port=8080`